### PR TITLE
Clarify Meaning of Default Mode Options

### DIFF
--- a/options.html
+++ b/options.html
@@ -19,8 +19,8 @@
         <select id="default-mode" disabled="disabled">
             <!--<option value="2">Autoplay & autobuffer</option>
             <option value="1">Autoplay only</option>-->
-            <option value="1">Autoplay</option>
-            <option value="0">Nothing</option>
+            <option value="1">Stop AutoPlay</option>
+            <option value="0">Play Videos Automatically</option>
         </select>
         <label id="default-mode-saving-status" for="default-mode" class="progress-text">Loading default mode...</label>
         <hr>


### PR DESCRIPTION
Clarify which option disables the effect of this plugin by default, 
    and which option disables autoplay playback by default.
I suggest:

  "Stop AutoPlay / Play Videos Automatically"  instead of
  "Autoplay / Nothing"

It was not obvious whether choosing AutoPlay meant AutoPlay was On (a verb), or autoplay was Off by default.  Likewise is "Nothing" happening by default, or "Nothing is turned Off" by default.
I went to your documentation to find out. (To me the choices were counter-intuitive).

Some Other Suggestions are: 

  "Autoplay Disabled / Nothing Disabled", 
  "Autoplay is Disabled / Nothing is Disabled", 
  "Autoplay Disabled / Nothing is Disabled"
  "Disable Autoplay / Disable Nothing", 

- "Autoplay Off / Standard Playback", 

  "Plugin Turns Autoplay Off / Plugin only turns off autoplay according to mode rules list"
  "AutoPlay Off unless listed as an exception below / AutoPlay ON unless listed as an exception below", 

- "Turn AutoPlay Off / Leave AutoPlay On"
  "Play Videos Automatically by default / Do NOT Play Videos Automatically by default", 
- "Do NOT Play Videos Automatically / Play Videos Automatically",
- "Autoplay Off / Automatically Play Videos"

  "Disable AutoPlay / Leave Autoplay On", 
- "Disable Autoplay / Autoplay"
- "Disable Autoplay / Autoplay On"

- "AutoPlay Off / AutoPlay On"
  "AutoPlay Off / Automatically Play"
  "AutoPlay Off / Automatically Play Videos"
  "AutoPlay Off / Auto Play "

  "No Autoplay / Autoplay On"
  "No Autoplay / Automatically Play Vidoes"
  "No Autoplay / Play Videos Automatically"
- "AutoPlay Off / Play Videos Automatically"
- "AutoPlay Disabled / Play Videos Automatically"
  "Stop AutoPlay / Play Videos Automatically"
  "AutoPlay Stopped / Play Videos Automatically"

  "No Autoplay / AutoPlay"
  "No Autoplay / AutoPlay On"
