### PR TITLE
Fixed Youtube issue

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -113,6 +113,7 @@ function frame_script_code(m_frame_event_name) {
         var ytapi = element.parentElement.parentElement;
         var init_time = -1;
         var play_authorized = false; // Whether the play() function can be invoked or not.
+        var last_url = ""; // the URL where authorized (if authorized) for dynamic applications
         var play_pending = false; // Whether we are waiting for the video to start playing or not. Set to true between the time the user input callback fires and the first play call that arrives after said callback fires.
         var video_cued = !autobuffering || yt.config_.hasOwnProperty("PLAYER_CONFIG") && yt.config_.PLAYER_CONFIG.hasOwnProperty("args") && yt.config_.PLAYER_CONFIG.args.hasOwnProperty("el") && (yt.config_.PLAYER_CONFIG.args.el == "embedded"); // Whether the video is cued (a red play button is in the center with a large video thumbnail in the background)
 
@@ -123,6 +124,7 @@ function frame_script_code(m_frame_event_name) {
                 init_time = ytapi.getCurrentTime();
                 ytapi.cueVideoByPlayerVars(ytapi.getVideoData());
                 play_authorized = true;
+                last_url = window.location.href;
             };
         };
 
@@ -131,6 +133,7 @@ function frame_script_code(m_frame_event_name) {
                 ytapi.parentElement.removeEventListener(event_name, user_input_callback, true);
             };
             play_authorized = true;
+            last_url = window.location.href;
             play_pending = true;
         };
 
@@ -171,7 +174,10 @@ function frame_script_code(m_frame_event_name) {
                         return;
                     };
                 } else if (element.src.length === 0 && !play_pending) {
-                    play_authorized = false;
+                    //play_authorized = false;
+                	if (play_authorized && window.location.href != last_url){
+                		play_authorized = false;
+                	}
                     add_user_input_listeners();
                     if (video_cued) {
                         return;

--- a/content_script.js
+++ b/content_script.js
@@ -1,3 +1,12 @@
+//window.document.addEventListener("onload",
+
+runHTML5AutoplayDisable = function(){
+// begin content
+
+//alert("Test 1: "+window.location.href);
+
+
+
 function frame_script_code(m_frame_event_name) {
     function send_message(message) {
         setTimeout(function() { window.dispatchEvent(new CustomEvent(m_frame_event_name, { detail: message })); }, 0);
@@ -50,6 +59,7 @@ function frame_script_code(m_frame_event_name) {
     };
 
     function BrowserControlsDelegate(element, check_type_matches) { // Delegate that handles media with native browser controls
+    	debug_function("BrowserControlsDelegate");
         if (check_type_matches == true) {
             return (element.controls == true);
         };
@@ -94,6 +104,9 @@ function frame_script_code(m_frame_event_name) {
             });
         };
     };
+    
+    var debug_function = function(){};
+    //debug_function = alert;
 
     function YouTubeDelegate(element, check_type_matches) { // Delegate that handles YouTube media
         if (check_type_matches == true) {
@@ -125,6 +138,7 @@ function frame_script_code(m_frame_event_name) {
                 ytapi.cueVideoByPlayerVars(ytapi.getVideoData());
                 play_authorized = true;
                 last_url = window.location.href;
+                debug_function("Autoplay enabled");
             };
         };
 
@@ -135,6 +149,7 @@ function frame_script_code(m_frame_event_name) {
             play_authorized = true;
             last_url = window.location.href;
             play_pending = true;
+            debug_function("Autoplay enabled");
         };
 
         function add_user_input_listeners() {
@@ -177,6 +192,7 @@ function frame_script_code(m_frame_event_name) {
                     //play_authorized = false;
                 	if (play_authorized && window.location.href != last_url){
                 		play_authorized = false;
+                		debug_function("Autoplay disabled");
                 	}
                     add_user_input_listeners();
                     if (video_cued) {
@@ -210,11 +226,13 @@ function frame_script_code(m_frame_event_name) {
 
     function VideojsDelegate(element, check_type_matches) { // Delegate that handles Video.js media
         if (check_type_matches == true) {
+        return false;
             if (element.classList.contains("vjs-tech") == true) {
                 return element.parentElement.classList.contains("video-js") && window.hasOwnProperty("videojs");
             };
             return false;
         };
+      debug_function("Video js delegate");
 
         var self = this;
 
@@ -257,7 +275,9 @@ function frame_script_code(m_frame_event_name) {
     };
 
     function JWPlayerDelegate(element, check_type_matches) { // Delegate that handles JWPlayer media
+    	debug_function("JWPlayer delegate");
         if (check_type_matches == true) {
+            return false;
             return (element.classList.contains("jw-video") && element.parentElement.classList.contains("jw-media") && element.parentElement.parentElement.classList.contains("jwplayer") && window.hasOwnProperty("jwplayer"));
         };
 
@@ -294,6 +314,7 @@ function frame_script_code(m_frame_event_name) {
     };
 
     function UnknownDelegate(element, check_type_matches) { // Delegate that is used for any other media in the DOM
+    	debug_function("Unknown delegate");
         if (check_type_matches == true) {
             return true;
         };
@@ -501,3 +522,17 @@ function handle_message(event) {
 
 window.addEventListener("message", handle_message, false);
 window.postMessage("DisableHTML5Autoplay_Initialize", "*");
+
+
+
+
+}; // end add event listener onload
+
+
+var debug_url = "";
+if (typeof loaded == "undefined"){
+	if (typeof debug_url != "string" || debug_url == "" || debug_url == window.location.href){
+    	loaded = true;
+		runHTML5AutoplayDisable();
+    }
+}

--- a/content_script.js
+++ b/content_script.js
@@ -1,12 +1,3 @@
-//window.document.addEventListener("onload",
-
-runHTML5AutoplayDisable = function(){
-// begin content
-
-//alert("Test 1: "+window.location.href);
-
-
-
 function frame_script_code(m_frame_event_name) {
     function send_message(message) {
         setTimeout(function() { window.dispatchEvent(new CustomEvent(m_frame_event_name, { detail: message })); }, 0);
@@ -59,7 +50,6 @@ function frame_script_code(m_frame_event_name) {
     };
 
     function BrowserControlsDelegate(element, check_type_matches) { // Delegate that handles media with native browser controls
-    	debug_function("BrowserControlsDelegate");
         if (check_type_matches == true) {
             return (element.controls == true);
         };
@@ -104,9 +94,6 @@ function frame_script_code(m_frame_event_name) {
             });
         };
     };
-    
-    var debug_function = function(){};
-    //debug_function = alert;
 
     function YouTubeDelegate(element, check_type_matches) { // Delegate that handles YouTube media
         if (check_type_matches == true) {
@@ -138,7 +125,6 @@ function frame_script_code(m_frame_event_name) {
                 ytapi.cueVideoByPlayerVars(ytapi.getVideoData());
                 play_authorized = true;
                 last_url = window.location.href;
-                debug_function("Autoplay enabled");
             };
         };
 
@@ -149,7 +135,6 @@ function frame_script_code(m_frame_event_name) {
             play_authorized = true;
             last_url = window.location.href;
             play_pending = true;
-            debug_function("Autoplay enabled");
         };
 
         function add_user_input_listeners() {
@@ -192,7 +177,6 @@ function frame_script_code(m_frame_event_name) {
                     //play_authorized = false;
                 	if (play_authorized && window.location.href != last_url){
                 		play_authorized = false;
-                		debug_function("Autoplay disabled");
                 	}
                     add_user_input_listeners();
                     if (video_cued) {
@@ -226,13 +210,11 @@ function frame_script_code(m_frame_event_name) {
 
     function VideojsDelegate(element, check_type_matches) { // Delegate that handles Video.js media
         if (check_type_matches == true) {
-        return false;
             if (element.classList.contains("vjs-tech") == true) {
                 return element.parentElement.classList.contains("video-js") && window.hasOwnProperty("videojs");
             };
             return false;
         };
-      debug_function("Video js delegate");
 
         var self = this;
 
@@ -275,9 +257,7 @@ function frame_script_code(m_frame_event_name) {
     };
 
     function JWPlayerDelegate(element, check_type_matches) { // Delegate that handles JWPlayer media
-    	debug_function("JWPlayer delegate");
         if (check_type_matches == true) {
-            return false;
             return (element.classList.contains("jw-video") && element.parentElement.classList.contains("jw-media") && element.parentElement.parentElement.classList.contains("jwplayer") && window.hasOwnProperty("jwplayer"));
         };
 
@@ -314,7 +294,6 @@ function frame_script_code(m_frame_event_name) {
     };
 
     function UnknownDelegate(element, check_type_matches) { // Delegate that is used for any other media in the DOM
-    	debug_function("Unknown delegate");
         if (check_type_matches == true) {
             return true;
         };
@@ -522,17 +501,3 @@ function handle_message(event) {
 
 window.addEventListener("message", handle_message, false);
 window.postMessage("DisableHTML5Autoplay_Initialize", "*");
-
-
-
-
-}; // end add event listener onload
-
-
-var debug_url = "";
-if (typeof loaded == "undefined"){
-	if (typeof debug_url != "string" || debug_url == "" || debug_url == window.location.href){
-    	loaded = true;
-		runHTML5AutoplayDisable();
-    }
-}


### PR DESCRIPTION
Once the user authorizes to play, autoplay is enabled in the future on
that particular URL. window.location.href tracking is added to prevent
autoplay on dynamic websites like Youtube, where the video is changed,
but the page is not reloaded. In that case, Youtube changes the URL via
HTML5 history API.

The site is free to autoplay advertisements on the same video or
article URL. This is appropriate, since an Ad-Blocker is needed to skip
these advertisements, and since they are generally continuous with the
video playing.

The main part of the fix has been tested for months and definitely
fixes the issue with Youtube videos.